### PR TITLE
Hotfix/use get for dc oai querying

### DIFF
--- a/app/oai_pmh_client.py
+++ b/app/oai_pmh_client.py
@@ -64,12 +64,12 @@ class OAIPMHClient(object):
     def _extract_file_locations(self, record):
         file_locations = []
         if self.use_ore:
-            for l in record['ore']['link']:
+            for l in record['ore'].get('link', []):
                 relation = l.get('rel', '')
                 if relation == 'http://www.openarchives.org/ore/terms/aggregates':
                     file_locations.append(l.get('href', ''))
         else:
-            for identifier in record['oai_dc']['identifier']:
+            for identifier in record['oai_dc'].get('identifier'):
                 if identifier.startswith(('http://', 'https://')):
                     file_locations.append(identifier)
         return list(filter(None, file_locations))

--- a/app/oai_pmh_client.py
+++ b/app/oai_pmh_client.py
@@ -69,7 +69,7 @@ class OAIPMHClient(object):
                 if relation == 'http://www.openarchives.org/ore/terms/aggregates':
                     file_locations.append(l.get('href', ''))
         else:
-            for identifier in record['oai_dc'].get('identifier'):
+            for identifier in record['oai_dc'].get('identifier', []):
                 if identifier.startswith(('http://', 'https://')):
                     file_locations.append(identifier)
         return list(filter(None, file_locations))


### PR DESCRIPTION
The DC spec isn't prescriptive about the inclusion of an `identifier` element, so doing a key lookup for this to find potential file locations runs the risk of a `KeyError` - this PR uses `.get()` with a default value of an empty list to prevent the adaptor erroring out if there are no `identifier`s in the DC response.  